### PR TITLE
Improvement on AddCommand regex.

### DIFF
--- a/src/main/java/harmony/mastermind/logic/commands/AddCommand.java
+++ b/src/main/java/harmony/mastermind/logic/commands/AddCommand.java
@@ -27,35 +27,41 @@ import harmony.mastermind.model.task.*;
 // @@author A0138862W
 public class AddCommand extends Command implements Undoable {
 
-    // http://stackoverflow.com/questions/24472120/match-optional-components-in-any-order
-    // the Add command can have multiple aliases, the naming convention is
-    // COMMAND_KEYWORD_<command_keyword>
     public static final String COMMAND_KEYWORD_ADD = "add";
     public static final String COMMAND_KEYWORD_DO = "do";
 
+    // The main idea of capturing parameters in any order is inspired by (author
+    // velop):
+    // http://stackoverflow.com/questions/1177081/mulitple-words-in-any-order-using-regex
+
+    // As for capturing optional group AND in any order:
+    // http://stackoverflow.com/questions/24472120/match-optional-components-in-any-order
+
+    // We wrote the regular expression and tested at:
+    // https://regex101.com/r/bFQrP6/1
     // @@author A0138862W
-    public static final String COMMAND_ARGUMENTS_REGEX = "(?=(?:.*?name\\/\"(?<name>.+?)\"))"
-                                                         + "(?=(?:.*?startDate\\/\"(?<startDate>.+?)\")?)"
-                                                         + "(?=(?:.*?endDate\\/\"(?<endDate>.+?)\")?)"
-                                                         + "(?=(?:.*tags\\/(?<tags>\\w+(?:,\\w+)*)?)?)"
+    public static final String COMMAND_ARGUMENTS_REGEX = "(?=(?:.*?\\s\\'(?<name>.+?)'))"
+                                                         + "(?=(?:.*?sd\\/'(?<startDate>.+?)')?)"
+                                                         + "(?=(?:.*?ed\\/'(?<endDate>.+?)')?)"
+                                                         + "(?=(?:.*t\\/'(?<tags>\\w+(?:,\\w+)*)?')?)"
                                                          + ".*";
 
     public static final Pattern COMMAND_ARGUMENTS_PATTERN = Pattern.compile(COMMAND_ARGUMENTS_REGEX);
 
-    public static final String COMMAND_SUMMARY = "Adding a task:"
-                                                 + "\n"
-                                                 + "("
-                                                 + COMMAND_KEYWORD_ADD
-                                                 + " | "
-                                                 + COMMAND_KEYWORD_DO
-                                                 + ") "
-                                                 + " name/\"<taskName>\" [startDate/\"<start_date\">] [endDate/\"<end_date\">] [tags/<comma_spearated_tags>]";
+    public static final String COMMAND_FORMAT = "(add|do) '<name>' [sd/'<startDate>'] [ed/'<endDate>'] [t/'<tags>...']";
 
-    public static final String MESSAGE_USAGE = COMMAND_SUMMARY
-                                               + "\n"
-                                               + "Example: "
-                                               + COMMAND_KEYWORD_ADD
-                                               + " name/\"do laundry\" startDate/\"today\" endDate/\"next friday 6pm\"";
+    public static final String MESSAGE_EXAMPLE_EVENT = "add 'attend workshop' sd/'today 7pm' ed/'next monday 1pm' t/'programming,java'";
+    public static final String MESSAGE_EXAMPLE_DEADLINE = "add 'submit homework' ed/'next sunday 11pm' t/'math,physics'";
+    public static final String MESSAGE_EXAMPLE_FLOATING = "do 'chores' t/'cleaning'";
+    
+    public static final String MESSAGE_EXAMPLES = new StringBuilder()
+                                                    .append("[Format]\n")
+                                                    .append(COMMAND_FORMAT+ "\n\n")
+                                                    .append("[Examples]:\n")
+                                                    .append("Event: "+ MESSAGE_EXAMPLE_EVENT+"\n")
+                                                    .append("Deadline: "+MESSAGE_EXAMPLE_DEADLINE+"\n")
+                                                    .append("Floating: "+MESSAGE_EXAMPLE_FLOATING)
+                                                    .toString();
 
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";
     public static final String MESSAGE_UNDO_SUCCESS = "[Undo Add Command] Task deleted: %1$s";
@@ -118,7 +124,7 @@ public class AddCommand extends Command implements Undoable {
     }
 
     @Override
-    /** action to perform when ModelManager requested to undo this command**/
+    /** action to perform when ModelManager requested to undo this command **/
     // @@author A0138862W
     public CommandResult undo() {
         try {

--- a/src/main/java/harmony/mastermind/logic/commands/HelpCommand.java
+++ b/src/main/java/harmony/mastermind/logic/commands/HelpCommand.java
@@ -18,7 +18,7 @@ public class HelpCommand extends Command {
             + "\n" + COMMAND_WORD;
     
     public static final String SHOWING_HELP_MESSAGE = "===Command Summary==="
-            + "\n" + AddCommand.COMMAND_SUMMARY + "\n"
+            + "\n" + AddCommand.COMMAND_FORMAT + "\n"
             + "\n" + EditCommand.COMMAND_SUMMARY + "\n"
             + "\n" + UndoCommand.COMMAND_SUMMARY + "\n"
             + "\n" + MarkCommand.COMMAND_SUMMARY + "\n"

--- a/src/main/java/harmony/mastermind/logic/parser/Parser.java
+++ b/src/main/java/harmony/mastermind/logic/parser/Parser.java
@@ -123,11 +123,12 @@ public class Parser {
      */
     // @@author A0138862W
     private Command prepareAdd(String args) {
-        final Matcher matcher = AddCommand.COMMAND_ARGUMENTS_PATTERN.matcher(args.trim());
+        final Matcher matcher = AddCommand.COMMAND_ARGUMENTS_PATTERN.matcher(args);
 
         // Validate arg string format
         if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            System.out.println("WTF");
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_EXAMPLES));
         }
 
         try {

--- a/src/test/java/harmony/mastermind/logic/LogicManagerTest.java
+++ b/src/test/java/harmony/mastermind/logic/LogicManagerTest.java
@@ -152,7 +152,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_add_invalidArgsFormat() throws Exception {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_EXAMPLES);
         assertCommandBehavior("add wrong args wrong args", expectedMessage);
         assertCommandBehavior("add Valid Name 12345 e/valid@email.butNoPhonePrefix a/valid, address", expectedMessage);
         assertCommandBehavior("add Valid Name p/12345 valid@email.butNoPrefix a/valid, address", expectedMessage);
@@ -182,7 +182,8 @@ public class LogicManagerTest {
         TestDataHelper helper = new TestDataHelper();
         Task toBeAdded = helper.task();
 
-        logic.execute(helper.generateAddCommand(toBeAdded));
+        System.out.println(helper.generateAddCommand(toBeAdded));
+        System.out.println(logic.execute(helper.generateAddCommand(toBeAdded)).feedbackToUser);
         
         assertCommandBehavior("undo", "Undo successfully.\n"
                 + "=====Undo Details=====\n"
@@ -601,12 +602,12 @@ public class LogicManagerTest {
         String generateAddCommand(Task p) {
             StringBuffer cmd = new StringBuffer();
 
-            cmd.append("add ");
+            cmd.append("add");
 
-            cmd.append(" name/\"").append(p.getName().toString()+"\"");
-            cmd.append(" startDate/\"").append(p.getStartDate()+"\"");
-            cmd.append(" endDate/\"").append(p.getEndDate()+"\"");
-            cmd.append(" tags/");
+            cmd.append(" '").append(p.getName().toString()+"'");
+            cmd.append(" sd/'").append(p.getStartDate()+"'");
+            cmd.append(" ed/'").append(p.getEndDate()+"'");
+            cmd.append(" t/'");
 
             UniqueTagList tags = p.getTags();
             for (Tag t: tags) {
@@ -615,6 +616,7 @@ public class LogicManagerTest {
             }
             
             cmd.deleteCharAt(cmd.length()-1);
+            cmd.append("'");
 
             return cmd.toString();
         }

--- a/src/test/java/harmony/mastermind/testutil/TestTask.java
+++ b/src/test/java/harmony/mastermind/testutil/TestTask.java
@@ -39,11 +39,13 @@ public class TestTask implements ReadOnlyTask {
     //@@author A0124797R
     public String getAddCommand() {
         StringBuilder sb = new StringBuilder();
-        sb.append("add name/\"" + this.getName() + "\" ");
-        sb.append("tags/");
+        sb.append("add");
+        sb.append(" '" + this.getName() + "' ");
+        sb.append("t/'");
         this.getTags().getInternalList().stream().forEach(s -> sb.append(s.tagName + ","));
 
         sb.deleteCharAt(sb.length()-1);
+        sb.append("'");
         return sb.toString();
         
     }


### PR DESCRIPTION
``` java
[Format]
(add|do) '<name>' [sd/'<startDate>'] [ed/'<endDate>'] [t/'<tags>...']

[Examples]:
Event: add 'attend workshop' sd/'today 7pm' ed/'next monday 1pm' t/'programming,java'
Deadline: add 'submit homework' ed/'next sunday 11pm' t/'math,physics'
Floating: do 'chores' t/'cleaning'
```
