### PR TITLE
Added ExportCommand to export to CSV (Google Calendar Compatible)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ allprojects {
         compile 'org.ocpsoft.prettytime:prettytime:4.0.1.Final'
         compile 'org.ocpsoft.prettytime:prettytime-nlp:4.0.0.Final'
         compile 'net.sf.biweekly:biweekly:0.6.0'
+        compile group: 'org.apache.commons', name: 'commons-csv', version: '1.1'
+
 
         testCompile "junit:junit:$junitVersion"
         testCompile "org.testfx:testfx-core:$testFxVersion"

--- a/src/main/java/harmony/mastermind/logic/commands/ExportCommand.java
+++ b/src/main/java/harmony/mastermind/logic/commands/ExportCommand.java
@@ -1,0 +1,140 @@
+package harmony.mastermind.logic.commands;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+
+import harmony.mastermind.commons.core.UnmodifiableObservableList;
+import harmony.mastermind.model.task.ReadOnlyTask;
+
+public class ExportCommand extends Command {
+
+    public static final String COMMAND_KEYWORD_EXPORT = "export";
+
+    public static final String COMMAND_ARGUMENTS_REGEX = "(?:(?=.*(?<tasks>tasks)))?"
+                                                         + "(?:(?=.*(?<deadlines>deadlines)))?"
+                                                         + "(?:(?=.*(?<events>events)))?"
+                                                         + "(?:(?=.*(?<archives>archives)))?"
+                                                         + ".*to "
+                                                         + "(?<destination>.+)";
+
+    public static final Pattern COMMAND_ARGUMENTS_PATTERN = Pattern.compile(COMMAND_ARGUMENTS_REGEX);
+
+    public static final String COMMAND_FORMAT = "export [tasks] [deadlines] [events] [archives] to <destination>";
+
+    public static final String MESSAGE_EXAMPLE = "export tasks deadlines to C:\\Desktop\\mastermind.csv";
+
+    public static final String MESSAGE_SUCCESS = "CSV exported.";
+
+    private static final String NEWLINE_CHARACTER = "\n";
+
+    private static final Object[] GOOGLE_CALENDAR_HEADER = { "Subject", "Start Date", "Start Time", "End Date", "End Time", "All Day Event", "Description", "Location", "Private" };
+
+    private static final SimpleDateFormat GOOGLE_CALENDAR_DATE_FORMAT = new SimpleDateFormat("MM/dd/yyyy");
+
+    private static final SimpleDateFormat GOOGLE_CALENDAR_TIME_FORMAT = new SimpleDateFormat("HH:mm");
+
+    private final String destination;
+
+    private final boolean isExportingTasks;
+
+    private final boolean isExportingDeadlines;
+
+    private final boolean isExportingEvents;
+
+    private final boolean isExportingArchives;
+
+    public ExportCommand(String destination, boolean isExportingTasks, boolean isExportingDeadlines, boolean isExportingEvents, boolean isExportingArchives) throws IOException {
+        this.destination = destination;
+        this.isExportingTasks = isExportingTasks;
+        this.isExportingDeadlines = isExportingDeadlines;
+        this.isExportingEvents = isExportingEvents;
+        this.isExportingArchives = isExportingArchives;
+    }
+
+    @Override
+    public CommandResult execute() {
+
+        CSVFormat csvFormat = CSVFormat.EXCEL;
+
+        try (FileWriter fileWriter = new FileWriter(destination); CSVPrinter csvPrinter = new CSVPrinter(fileWriter, csvFormat);) {
+            printHeader(csvPrinter);
+            printTasks(csvPrinter);
+            printDeadlines(csvPrinter);
+            printEvents(csvPrinter);
+            printArchives(csvPrinter);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return new CommandResult(COMMAND_KEYWORD_EXPORT, MESSAGE_SUCCESS);
+    }
+
+    private void printHeader(CSVPrinter csvPrinter) throws IOException {
+        csvPrinter.printRecord(GOOGLE_CALENDAR_HEADER);
+    }
+
+    private void printTasks(CSVPrinter csvPrinter) throws IOException {
+        if (isExportingTasks) {
+            UnmodifiableObservableList<ReadOnlyTask> tasks = model.getFilteredFloatingTaskList();
+            printDataBody(csvPrinter, tasks);
+        }
+    }
+    
+    private void printDeadlines(CSVPrinter csvPrinter) throws IOException{
+        if(isExportingDeadlines){
+            UnmodifiableObservableList<ReadOnlyTask> deadlines = model.getFilteredDeadlineList();
+            printDataBody(csvPrinter, deadlines);
+        }
+    }
+    
+    private void printEvents(CSVPrinter csvPrinter) throws IOException{
+        if(isExportingEvents){
+            UnmodifiableObservableList<ReadOnlyTask> events = model.getFilteredEventList();
+            printDataBody(csvPrinter, events);
+        }
+    }
+    
+    private void printArchives(CSVPrinter csvPrinter) throws IOException{
+        if(isExportingArchives){
+            UnmodifiableObservableList<ReadOnlyTask> archives = model.getFilteredArchiveList();
+            printDataBody(csvPrinter, archives);
+        }
+    }
+
+    private void printDataBody(CSVPrinter csvPrinter, UnmodifiableObservableList<ReadOnlyTask> tasks) throws IOException {
+        for (ReadOnlyTask task : tasks) {
+            List<Object> data = new ArrayList<>();
+            data.add(task.getName());
+            if(task.isFloating()){
+                Date dummyDate = new Date();
+                data.add(GOOGLE_CALENDAR_DATE_FORMAT.format(dummyDate));
+                data.add(GOOGLE_CALENDAR_TIME_FORMAT.format(dummyDate));
+                data.add(GOOGLE_CALENDAR_DATE_FORMAT.format(dummyDate));
+                data.add(GOOGLE_CALENDAR_TIME_FORMAT.format(dummyDate));
+            } else if (task.isDeadline()){
+                data.add(GOOGLE_CALENDAR_DATE_FORMAT.format(task.getEndDate()));
+                data.add(GOOGLE_CALENDAR_TIME_FORMAT.format(task.getEndDate()));
+                data.add(GOOGLE_CALENDAR_DATE_FORMAT.format(task.getEndDate()));
+                data.add(GOOGLE_CALENDAR_TIME_FORMAT.format(task.getEndDate()));
+            } else if (task.isEvent()){
+                data.add(GOOGLE_CALENDAR_DATE_FORMAT.format(task.getStartDate()));
+                data.add(GOOGLE_CALENDAR_TIME_FORMAT.format(task.getStartDate()));
+                data.add(GOOGLE_CALENDAR_DATE_FORMAT.format(task.getEndDate()));
+                data.add(GOOGLE_CALENDAR_TIME_FORMAT.format(task.getEndDate()));
+            }
+            data.add((task.isFloating())? "TRUE": "FALSE");
+            data.add(task.getTags().toString().replaceAll(",", " "));
+            data.add(null);
+            data.add("TRUE");
+            csvPrinter.printRecord(data);
+        }
+    }
+
+}

--- a/src/main/java/harmony/mastermind/logic/commands/ExportCommand.java
+++ b/src/main/java/harmony/mastermind/logic/commands/ExportCommand.java
@@ -14,6 +14,7 @@ import org.apache.commons.csv.CSVPrinter;
 import harmony.mastermind.commons.core.UnmodifiableObservableList;
 import harmony.mastermind.model.task.ReadOnlyTask;
 
+//@@author A0138862W
 public class ExportCommand extends Command {
 
     public static final String COMMAND_KEYWORD_EXPORT = "export";
@@ -32,6 +33,8 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_EXAMPLE = "export tasks deadlines to C:\\Desktop\\mastermind.csv";
 
     public static final String MESSAGE_SUCCESS = "CSV exported.";
+    
+    public static final String MESSAGE_FAILURE = "Failed to export CSV.";
 
     private static final String NEWLINE_CHARACTER = "\n";
 
@@ -51,6 +54,17 @@ public class ExportCommand extends Command {
 
     private final boolean isExportingArchives;
 
+    //@@author A0138862W
+    /**
+     * Create a ExportCommand
+     * 
+     * @param destination the file output destination
+     * @param isExportingTasks whether to export all floating tasks
+     * @param isExportingDeadlines whether to export all deadlines
+     * @param isExportingEvents whether to export all events
+     * @param isExportingArchives whether to export all archives
+     * @throws IOException if destination file path is invalid
+     */
     public ExportCommand(String destination, boolean isExportingTasks, boolean isExportingDeadlines, boolean isExportingEvents, boolean isExportingArchives) throws IOException {
         this.destination = destination;
         this.isExportingTasks = isExportingTasks;
@@ -59,6 +73,7 @@ public class ExportCommand extends Command {
         this.isExportingArchives = isExportingArchives;
     }
 
+    //@@author A0138862W
     @Override
     public CommandResult execute() {
 
@@ -70,16 +85,18 @@ public class ExportCommand extends Command {
             printDeadlines(csvPrinter);
             printEvents(csvPrinter);
             printArchives(csvPrinter);
+            return new CommandResult(COMMAND_KEYWORD_EXPORT, MESSAGE_SUCCESS);
         } catch (IOException e) {
-            e.printStackTrace();
+            return new CommandResult(COMMAND_KEYWORD_EXPORT, MESSAGE_FAILURE);
         }
-        return new CommandResult(COMMAND_KEYWORD_EXPORT, MESSAGE_SUCCESS);
     }
 
+    //@@author A0138862W
     private void printHeader(CSVPrinter csvPrinter) throws IOException {
         csvPrinter.printRecord(GOOGLE_CALENDAR_HEADER);
     }
 
+    //@@author A0138862W
     private void printTasks(CSVPrinter csvPrinter) throws IOException {
         if (isExportingTasks) {
             UnmodifiableObservableList<ReadOnlyTask> tasks = model.getFilteredFloatingTaskList();
@@ -87,6 +104,7 @@ public class ExportCommand extends Command {
         }
     }
     
+    //@@author A0138862W
     private void printDeadlines(CSVPrinter csvPrinter) throws IOException{
         if(isExportingDeadlines){
             UnmodifiableObservableList<ReadOnlyTask> deadlines = model.getFilteredDeadlineList();
@@ -94,13 +112,15 @@ public class ExportCommand extends Command {
         }
     }
     
+    //@@author A0138862W
     private void printEvents(CSVPrinter csvPrinter) throws IOException{
         if(isExportingEvents){
             UnmodifiableObservableList<ReadOnlyTask> events = model.getFilteredEventList();
             printDataBody(csvPrinter, events);
         }
     }
-    
+
+    //@@author A0138862W
     private void printArchives(CSVPrinter csvPrinter) throws IOException{
         if(isExportingArchives){
             UnmodifiableObservableList<ReadOnlyTask> archives = model.getFilteredArchiveList();
@@ -108,6 +128,21 @@ public class ExportCommand extends Command {
         }
     }
 
+    //@@author A0138862W
+    /**
+     * A helper method to print list of tasks into csv.
+     * Due to the limitation of Google Calendar (must specify start and end date):
+     * 
+     * - Floating tasks are assigned with dummy date (exported date) as their start and end date, in addition set the all day event as true.
+     * - Deadlines will share the same start and end dates
+     * - Event will and distinct start and end dates
+     * 
+     * All tags are exported under descriptions
+     * 
+     * @param csvPrinter CSVPrinter object
+     * @param tasks list of tasks to print
+     * @throws IOException if file is not writable
+     */
     private void printDataBody(CSVPrinter csvPrinter, UnmodifiableObservableList<ReadOnlyTask> tasks) throws IOException {
         for (ReadOnlyTask task : tasks) {
             List<Object> data = new ArrayList<>();

--- a/src/test/java/guitests/ExportCommandTest.java
+++ b/src/test/java/guitests/ExportCommandTest.java
@@ -1,0 +1,77 @@
+package guitests;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+//@@author A0138862W
+public class ExportCommandTest extends TaskManagerGuiTest{
+
+    //@@author A0138862W
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+    
+    //@@author A0138862W
+    @Before
+    public void before(){
+        this.commandBox.runCommand("clear");
+        this.assertListSize(0);
+        
+        //add a floating task
+        this.commandBox.runCommand("add a floating task");
+        this.assertListSize(1);
+        
+        //add a deadline
+        this.commandBox.runCommand("add a deadline by next friday 7pm");
+        this.assertListSize(2);
+        
+        //add an event
+        this.commandBox.runCommand("add an event from tomorrow 8pm to next monday 7pm");
+        this.assertListSize(3);
+    }
+    
+    //@@author A0138862W
+    @Test
+    public void export_success() throws IOException{
+        final long EXPECTED_FILE_LENGTH_ALLCSV = 271;
+        final long EXPECTED_FILE_LENGTH_TASKSCSV = 155;
+        final long EXPECTED_FILE_LENGTH_DEADLINESEVENTSCSV = 208;
+        
+        // export all tasks
+        File allCsv = testFolder.newFile("all.csv");
+        this.commandBox.runCommand("export to "+allCsv.getAbsolutePath());
+        this.assertResultMessage("CSV exported.");
+        assertTrue(allCsv.exists());
+        assertEquals(EXPECTED_FILE_LENGTH_ALLCSV, allCsv.length());
+        
+        // export only floating tasks
+        File tasksCsv = testFolder.newFile("tasks.csv");
+        this.commandBox.runCommand("export tasks to "+tasksCsv.getAbsolutePath());
+        this.assertResultMessage("CSV exported.");
+        assertTrue(tasksCsv.exists());
+        assertEquals(EXPECTED_FILE_LENGTH_TASKSCSV, tasksCsv.length());
+        
+        // export deadlines and events 
+        File deadlinesEventsCsv = testFolder.newFile("deadlines-events.csv");
+        this.commandBox.runCommand("export deadlines events to "+deadlinesEventsCsv.getAbsolutePath());
+        this.assertResultMessage("CSV exported.");
+        assertTrue(deadlinesEventsCsv.exists());
+        assertEquals(EXPECTED_FILE_LENGTH_DEADLINESEVENTSCSV, deadlinesEventsCsv.length());
+    }
+    
+    //@@author A0138862W
+    @Test
+    public void export_failure_invalidFilePath(){
+        this.commandBox.runCommand("export to /invalid/file/path");
+        this.assertResultMessage("Failed to export CSV.");
+    }
+    
+    
+
+}


### PR DESCRIPTION
This PR allow exporting Mastermind task list to CSV, compatible for Google Calendar to import.

Format:

``` java
export [tasks] [deadlines] [events] [archives] to <destination>
```

> tasks, deadlines, events and archives are all optional and can be in any order

``` java
// export event and deadlines categories to the destination C:\Users\Jim\mastermind.csv
export events deadlines to C:\Users\Jim\mastermind.csv
```

> if none of the above options are specify, it defaults to exporting all categories

``` java
// export all categories to the destination C:\Users\Jim\mastermind.csv
export to C:\Users\Jim\mastermind.csv
```

> **NOTE:** Google Calendar does not support floating task, so we had no choice but to put in a dummy date (date exported), in addition the `All Day Event` column will be set to True
> **NOTE:** As for Deadlines, it will share the same start date and end date when exported to csv
> **NOTE:** Tags are exported under Description
