### PR TITLE
Improve add command nlp.

### DIFF
--- a/src/main/java/harmony/mastermind/logic/commands/AddCommand.java
+++ b/src/main/java/harmony/mastermind/logic/commands/AddCommand.java
@@ -32,10 +32,11 @@ public class AddCommand extends Command implements Undoable, Redoable {
     // Better regex, support better NLP:
     // general form: add some task name from tomorrow 8pm to next friday 8pm daily #recurring,awesome
     // https://regex101.com/r/M2A3tB/8
-    public static final String COMMAND_ARGUMENTS_REGEX = "(?=(?<name>(?:.(?!by|from|#))+))"
-                                                        + "(?:(?=.*(?:by|from)\\s(?<dates>(?:.(?!#))+)?))?"
+    public static final String COMMAND_ARGUMENTS_REGEX = "(?=(?<name>(?:'.+'|(?:.(?!by|from|#)))+))"
+                                                        + "(?:(?=.*(?:by|from)\\s(?<dates>(?:.(?!#|.*'))+)?))?"
                                                         + "(?:(?=.*(?<recur>daily|weekly|monthly|yearly)))?"
-                                                        + "(?:(?=.*#(?<tags>.+)))?.*";
+                                                        + "(?:(?=.*#(?<tags>.+)))?"
+                                                        + ".*";
 
     public static final Pattern COMMAND_ARGUMENTS_PATTERN = Pattern.compile(COMMAND_ARGUMENTS_REGEX);
     


### PR DESCRIPTION
Add command now uses optional `single quotes '` to escape keywords like from or to.
User has to be aware of their task name if it contains by, from, to and escape them using `single quotes '`

```java
add 'visit garden by the bay' from tonight 8pm

add 'watch movie from beyond' by next friday 8pm

add 'go to school' from 8am to 6pm
```

See [https://regex101.com/r/M2A3tB/15](https://regex101.com/r/M2A3tB/15) for the regex testing results.