### PR TITLE
Shorten the actionhistory command to just history

### DIFF
--- a/src/main/java/harmony/mastermind/logic/commands/HelpCommand.java
+++ b/src/main/java/harmony/mastermind/logic/commands/HelpCommand.java
@@ -64,7 +64,7 @@ public class HelpCommand extends Command {
         commandList.add(RelocateCommand.COMMAND_WORD);
         commandList.add(ImportCommand.COMMAND_WORD);
         commandList.add(ExportCommand.COMMAND_KEYWORD_EXPORT);
-        commandList.add(ActionHistoryCommand.COMMAND_KEYWORD_ACTIONHISTORY);
+        commandList.add(HistoryCommand.COMMAND_KEYWORD_ACTIONHISTORY);
         commandList.add(HelpCommand.COMMAND_WORD);
         commandList.add(ExitCommand.COMMAND_WORD);
     }
@@ -85,7 +85,7 @@ public class HelpCommand extends Command {
         formatList.add(RelocateCommand.COMMAND_FORMAT);
         formatList.add(ImportCommand.COMMAND_FORMAT);
         formatList.add(ExportCommand.COMMAND_FORMAT);
-        formatList.add(ActionHistoryCommand.COMMAND_KEYWORD_ACTIONHISTORY);
+        formatList.add(HistoryCommand.COMMAND_KEYWORD_ACTIONHISTORY);
         formatList.add(HelpCommand.COMMAND_WORD);
         formatList.add(ExitCommand.COMMAND_WORD);
     }
@@ -106,7 +106,7 @@ public class HelpCommand extends Command {
         descriptionList.add(RelocateCommand.COMMAND_DESCRIPTION);
         descriptionList.add(ImportCommand.COMMAND_DESCRIPTION);
         descriptionList.add(ExportCommand.COMMAND_DESCRIPTION);
-        descriptionList.add(ActionHistoryCommand.COMMAND_DESCRIPTION);
+        descriptionList.add(HistoryCommand.COMMAND_DESCRIPTION);
         descriptionList.add(HelpCommand.COMMAND_DESCRIPTION);
         descriptionList.add(ExitCommand.COMMAND_DESCRIPTION);
     }

--- a/src/main/java/harmony/mastermind/logic/commands/HistoryCommand.java
+++ b/src/main/java/harmony/mastermind/logic/commands/HistoryCommand.java
@@ -12,9 +12,9 @@ import harmony.mastermind.commons.events.ui.ToggleActionHistoryEvent;
  * @author kfwong
  *
  */
-public class ActionHistoryCommand extends Command {
+public class HistoryCommand extends Command {
 
-    public static final String COMMAND_KEYWORD_ACTIONHISTORY = "actionhistory";
+    public static final String COMMAND_KEYWORD_ACTIONHISTORY = "history";
     public static final String COMMAND_DESCRIPTION = "Toggles action history bar";
 
     public static final String MESSAGE_SUCCESS = "Action history toggled.";

--- a/src/main/java/harmony/mastermind/logic/parser/Parser.java
+++ b/src/main/java/harmony/mastermind/logic/parser/Parser.java
@@ -24,7 +24,7 @@ import com.google.common.base.Strings;
 import harmony.mastermind.commons.exceptions.IllegalValueException;
 import harmony.mastermind.commons.exceptions.InvalidEventDateException;
 import harmony.mastermind.commons.util.StringUtil;
-import harmony.mastermind.logic.commands.ActionHistoryCommand;
+import harmony.mastermind.logic.commands.HistoryCommand;
 import harmony.mastermind.logic.commands.AddCommand;
 import harmony.mastermind.logic.commands.AddCommandBuilder;
 import harmony.mastermind.logic.commands.ClearCommand;
@@ -144,8 +144,8 @@ public class Parser {
             case ExportCommand.COMMAND_KEYWORD_EXPORT:
                 return prepareExport(arguments);
                 
-            case ActionHistoryCommand.COMMAND_KEYWORD_ACTIONHISTORY:
-                return new ActionHistoryCommand();
+            case HistoryCommand.COMMAND_KEYWORD_ACTIONHISTORY:
+                return new HistoryCommand();
             default:
                 return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND+": "+userInput);
         }

--- a/src/main/java/harmony/mastermind/ui/CommandBox.java
+++ b/src/main/java/harmony/mastermind/ui/CommandBox.java
@@ -58,6 +58,16 @@ public class CommandBox extends UiPart {
     
     @FXML
     private TextField commandField;
+    
+    @FXML
+    private void initialize(){
+        Platform.runLater(new Runnable() {
+            @Override
+            public void run() {
+                commandField.requestFocus();
+            }
+        });
+    }
 
     public static CommandBox load(Stage primaryStage, AnchorPane commandBoxPlaceholder, Logic logic) {
         CommandBox commandBox = UiPartLoader.loadUiPart(primaryStage, commandBoxPlaceholder, new CommandBox());


### PR DESCRIPTION
toggle action history panel now uses shorter command syntax
```
history
```

- now application auto focus on textfield on launch.